### PR TITLE
Feature/pinned comment

### DIFF
--- a/public/language/en-GB/topic.json
+++ b/public/language/en-GB/topic.json
@@ -113,6 +113,8 @@
 	"thread-tools.markAsUnreadForAll": "Mark Unread For All",
 	"thread-tools.pin": "Pin Topic",
 	"thread-tools.unpin": "Unpin Topic",
+	"pin-comment": "Pin Comment",
+	"unpin-comment": "Unpin Comment",
 	"thread-tools.lock": "Lock Topic",
 	"thread-tools.unlock": "Unlock Topic",
 	"thread-tools.move": "Move Topic",

--- a/public/language/en-US/topic.json
+++ b/public/language/en-US/topic.json
@@ -100,6 +100,8 @@
     "thread-tools.markAsUnreadForAll": "Mark Unread For All",
     "thread-tools.pin": "Pin Topic",
     "thread-tools.unpin": "Unpin Topic",
+    "pin-comment": "Pin Comment",
+    "unpin-comment": "Unpin Comment",
     "thread-tools.lock": "Lock Topic",
     "thread-tools.unlock": "Unlock Topic",
     "thread-tools.move": "Move Topic",

--- a/public/src/client/topic/events.js
+++ b/public/src/client/topic/events.js
@@ -258,17 +258,28 @@ define('forum/topic/events', [
 			postEl.find('[component="post/pinned-indicator"]').removeClass('hidden');
 		}
 
-		// Move the pinned post directly under the main post (visually)
+		// Move the pinned post to the pinned section: after the last existing pinned post
 		try {
 			const topicEl = components.get('topic');
 			const mainPost = topicEl.find('[component="post"][data-index="0"]');
-			if (mainPost.length && mainPost[0] !== postEl[0]) {
+			// Find the last pinned post (excluding the one we're pinning)
+			let insertAfterEl = topicEl.find('[component="post"].pinned-post').not(postEl).last();
+			if (!insertAfterEl.length) {
+				// If there are no pinned posts, insert directly after the main post (if found)
+				insertAfterEl = mainPost.length ? mainPost : null;
+			}
+			if (insertAfterEl) {
 				// Store reference to the next sibling so we can restore on unpin
 				postEl.data('pin-previous-next', postEl.next());
-				postEl.insertAfter(mainPost);
+				// If insertAfterEl is mainPost and equals the post itself, skip
+				if (insertAfterEl[0] !== postEl[0]) {
+					postEl.insertAfter(insertAfterEl);
+				}
+			} else {
+				// As a last resort, append to topic container
+				topicEl.append(postEl);
 			}
 		} catch (e) {
-			// fail silently if components.get isn't available or DOM changes unexpectedly
 			console.warn('Unable to move pinned post in DOM', e);
 		}
 	}

--- a/public/src/client/topic/events.js
+++ b/public/src/client/topic/events.js
@@ -32,6 +32,8 @@ define('forum/topic/events', [
 		'event:topic_moved': onTopicMoved,
 
 		'event:post_edited': onPostEdited,
+		'event:post_pinned': onPostPinned,
+		'event:post_unpinned': onPostUnpinned,
 		'event:post_purged': onPostPurged,
 
 		'event:post_deleted': togglePostDeleteState,
@@ -226,6 +228,36 @@ define('forum/topic/events', [
 				}
 			});
 		}
+	}
+
+	function onPostPinned(data) {
+		if (!data || String(data.tid) !== String(ajaxify.data.tid)) {
+			return;
+		}
+		const postEl = components.get('post', 'pid', data.pid);
+		if (!postEl.length) {
+			return;
+		}
+		postEl.addClass('pinned-post');
+		postEl.find('[component="post/pin"]').toggleClass('hidden', true).parent().attr('hidden', '');
+		postEl.find('[component="post/unpin"]').toggleClass('hidden', false).parent().attr('hidden', null);
+		if (!postEl.find('[component="post/pinned"]').length) {
+			postEl.find('[component="post/header"]').append('<span component="post/pinned" class="badge bg-secondary ms-2"><i class="fa fa-thumb-tack"></i></span>');
+		}
+	}
+
+	function onPostUnpinned(data) {
+		if (!data || String(data.tid) !== String(ajaxify.data.tid)) {
+			return;
+		}
+		const postEl = components.get('post', 'pid', data.pid);
+		if (!postEl.length) {
+			return;
+		}
+		postEl.removeClass('pinned-post');
+		postEl.find('[component="post/pin"]').toggleClass('hidden', false).parent().attr('hidden', null);
+		postEl.find('[component="post/unpin"]').toggleClass('hidden', true).parent().attr('hidden', '');
+		postEl.find('[component="post/pinned"]').remove();
 	}
 
 	function togglePostBookmark(data) {

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -128,6 +128,28 @@ define('forum/topic/postTools', [
 		postContainer.on('click', '[component="post/bookmark"]', function () {
 			return bookmarkPost($(this), getData($(this), 'data-pid'));
 		});
+		// pin UI
+		postContainer.on('click', '[component="post/pin"]', function () {
+			const pid = getData($(this), 'data-pid');
+			api.put(`/posts/${encodeURIComponent(pid)}/pin`, undefined, function (err) {
+				if (err) {
+					return alerts.error(err);
+				}
+				hooks.fire('action:post.pinned', { pid: pid });
+			});
+			return false;
+		});
+		// unpin UI
+		postContainer.on('click', '[component="post/unpin"]', function () {
+			const pid = getData($(this), 'data-pid');
+			api.del(`/posts/${encodeURIComponent(pid)}/pin`, undefined, function (err) {
+				if (err) {
+					return alerts.error(err);
+				}
+				hooks.fire('action:post.unpinned', { pid: pid });
+			});
+			return false;
+		});
 
 		postContainer.on('click', '[component="post/upvote"]', function () {
 			return votes.toggleVote($(this), '.upvoted', 1);

--- a/src/api/posts.js
+++ b/src/api/posts.js
@@ -344,6 +344,87 @@ postsAPI.unvote = async function (caller, data) {
 	return await apiHelpers.postCommand(caller, 'unvote', 'voted', '', data);
 };
 
+postsAPI.pin = async function (caller, data) {
+	// check data
+	if (!data || !data.pid) {
+		throw new Error('[[error:invalid-data]]');
+	}
+	// check credentials
+	if (!caller.uid) {
+		throw new Error('[[error:not-logged-in]]');
+	}
+
+	const postData = await posts.getPostData(data.pid);
+	if (!postData) {
+		throw new Error('[[error:no-post]]');
+	}
+
+	const parentPid = await posts.getPostField(data.pid, 'toPid');
+	let isParentOwner = false;
+	// allow owner of the post to pin + unpin comments
+	if (parentPid) {
+		const parentOwner = await posts.getPostField(parentPid, 'uid');
+		isParentOwner = String(parentOwner) === String(caller.uid);
+	}
+	// also allow admin to do the same (given they have 'posts:pin' permissions)
+	const hasPrivilege = await privileges.posts.can('posts:pin', data.pid, caller.uid);
+	if (!isParentOwner && !hasPrivilege) {
+		throw new Error('[[error:no-privileges]]');
+	}
+
+	await posts.setPostFields(data.pid, { pinned: 1 });
+
+	websockets.in(`topic_${postData.tid}`).emit('event:post_pinned', { pid: data.pid, tid: postData.tid });
+
+	await events.log({
+		type: 'post-pin',
+		uid: caller.uid,
+		pid: data.pid,
+		tid: postData.tid,
+		ip: caller.ip,
+	});
+};
+
+// repeat steps for unpin
+postsAPI.unpin = async function (caller, data) {
+	if (!data || !data.pid) {
+		throw new Error('[[error:invalid-data]]');
+	}
+	if (!caller.uid) {
+		throw new Error('[[error:not-logged-in]]');
+	}
+	// Allow the owner of the parent post to pin/unpin replies to their post,
+	// or any user with the global 'posts:pin' privilege on this post.
+	const postData = await posts.getPostData(data.pid);
+	if (!postData) {
+		throw new Error('[[error:no-post]]');
+	}
+
+	const parentPid = await posts.getPostField(data.pid, 'toPid');
+	let isParentOwner = false;
+	if (parentPid) {
+		const parentOwner = await posts.getPostField(parentPid, 'uid');
+		isParentOwner = String(parentOwner) === String(caller.uid);
+	}
+
+	const hasPrivilege = await privileges.posts.can('posts:pin', data.pid, caller.uid);
+	if (!isParentOwner && !hasPrivilege) {
+		throw new Error('[[error:no-privileges]]');
+	}
+
+	await posts.setPostFields(data.pid, { pinned: 0 });
+
+	websockets.in(`topic_${postData.tid}`).emit('event:post_unpinned', { pid: data.pid, tid: postData.tid });
+
+	await events.log({
+		type: 'post-unpin',
+		uid: caller.uid,
+		pid: data.pid,
+		tid: postData.tid,
+		ip: caller.ip,
+	});
+};
+
 postsAPI.getVoters = async function (caller, data) {
 	if (!data || !data.pid) {
 		throw new Error('[[error:invalid-data]]');

--- a/src/controllers/write/posts.js
+++ b/src/controllers/write/posts.js
@@ -163,6 +163,16 @@ Posts.unbookmark = async (req, res) => {
 	helpers.formatApiResponse(200, res);
 };
 
+Posts.pin = async (req, res) => {
+	await api.posts.pin(req, { pid: req.params.pid });
+	helpers.formatApiResponse(200, res);
+};
+
+Posts.unpin = async (req, res) => {
+	await api.posts.unpin(req, { pid: req.params.pid });
+	helpers.formatApiResponse(200, res);
+};
+
 Posts.getDiffs = async (req, res) => {
 	helpers.formatApiResponse(200, res, await api.posts.getDiffs(req, { ...req.params }));
 };

--- a/src/posts/data.js
+++ b/src/posts/data.js
@@ -8,6 +8,7 @@ const intFields = [
 	'uid', 'pid', 'tid', 'deleted', 'timestamp',
 	'upvotes', 'downvotes', 'deleterUid', 'edited',
 	'replies', 'bookmarks', 'announces',
+	'pinned',
 ];
 
 module.exports = function (Posts) {

--- a/src/routes/write/posts.js
+++ b/src/routes/write/posts.js
@@ -34,6 +34,10 @@ module.exports = function () {
 	setupApiRoute(router, 'put', '/:pid/bookmark', middlewares, controllers.write.posts.bookmark);
 	setupApiRoute(router, 'delete', '/:pid/bookmark', middlewares, controllers.write.posts.unbookmark);
 
+	// allow post creator to pin and unpin comments in a post (issue #4)
+	setupApiRoute(router, 'put', '/:pid/pin', middlewares, controllers.write.posts.pin);
+	setupApiRoute(router, 'delete', '/:pid/pin', middlewares, controllers.write.posts.unpin);
+
 	setupApiRoute(router, 'get', '/:pid/diffs', [middleware.assert.post], controllers.write.posts.getDiffs);
 	setupApiRoute(router, 'get', '/:pid/diffs/:since', [middleware.assert.post], controllers.write.posts.loadDiff);
 	setupApiRoute(router, 'put', '/:pid/diffs/:since', middlewares, controllers.write.posts.restoreDiff);

--- a/src/socket.io/posts/tools.js
+++ b/src/socket.io/posts/tools.js
@@ -19,7 +19,7 @@ module.exports = function (SocketPosts) {
 		}
 		const cid = await posts.getCidByPid(data.pid);
 		const results = await utils.promiseParallel({
-			posts: posts.getPostFields(data.pid, ['deleted', 'bookmarks', 'uid', 'ip', 'flagId', 'url']),
+			posts: posts.getPostFields(data.pid, ['deleted', 'bookmarks', 'uid', 'ip', 'flagId', 'url', 'pinned']),
 			isAdmin: user.isAdministrator(socket.uid),
 			isGlobalMod: user.isGlobalModerator(socket.uid),
 			isModerator: user.isModerator(socket.uid, cid),
@@ -27,6 +27,7 @@ module.exports = function (SocketPosts) {
 			canDelete: privileges.posts.canDelete(data.pid, socket.uid),
 			canPurge: privileges.posts.canPurge(data.pid, socket.uid),
 			canFlag: privileges.posts.canFlag(data.pid, socket.uid),
+			canPin: privileges.posts.can('posts:pin', data.pid, socket.uid),
 			canViewHistory: privileges.posts.can('posts:history', data.pid, socket.uid),
 			flagged: flags.exists('post', data.pid, socket.uid), // specifically, whether THIS calling user flagged
 			bookmarked: posts.hasBookmarked(data.pid, socket.uid),
@@ -46,6 +47,16 @@ module.exports = function (SocketPosts) {
 		postData.display_flag_tools = socket.uid && results.canFlag.flag;
 		postData.display_moderator_tools = postData.display_edit_tools || postData.display_delete_tools;
 		postData.display_move_tools = results.isAdmin || results.isModerator;
+
+		// check if user can pin + unpin comments (either by being author or admin)
+		const canPinPriv = await privileges.posts.can('posts:pin', data.pid, socket.uid);
+		let isParentOwner = false;
+		const parentPid = await posts.getPostField(data.pid, 'toPid');
+		if (parentPid) {
+			const parentOwner = await posts.getPostField(parentPid, 'uid');
+			isParentOwner = String(parentOwner) === String(socket.uid);
+		}
+		postData.canPin = !!(canPinPriv || isParentOwner);
 		postData.display_change_owner_tools = results.isAdmin || results.isModerator;
 		postData.display_manage_editors_tools = results.isAdmin || results.isModerator || postData.selfPost;
 		postData.display_ip_ban = (results.isAdmin || results.isGlobalMod) && !postData.selfPost;

--- a/src/views/partials/topic/post-menu-list.tpl
+++ b/src/views/partials/topic/post-menu-list.tpl
@@ -19,12 +19,12 @@
 {{{ if posts.canPin }}}
 <li {{{ if posts.pinned }}}hidden{{{ end }}}>
 	<a class="dropdown-item rounded-1 d-flex align-items-center gap-2" component="post/pin" role="menuitem" href="#" data-pid="{posts.pid}">
-		<span class="menu-icon"><i class="fa fa-fw text-secondary fa-thumb-tack"></i></span> [[topic:pin-post]]
+		<span class="menu-icon"><i class="fa fa-fw text-secondary fa-thumb-tack"></i></span> [[topic:pin-comment]]
 	</a>
 </li>
 <li {{{ if !posts.pinned }}}hidden{{{ end }}}>
 	<a class="dropdown-item rounded-1 d-flex align-items-center gap-2" component="post/unpin" role="menuitem" href="#" data-pid="{posts.pid}">
-		<span class="menu-icon"><i class="fa fa-fw text-secondary fa-thumb-tack fa-rotate-90"></i></span> [[topic:unpin-post]]
+		<span class="menu-icon"><i class="fa fa-fw text-secondary fa-thumb-tack fa-rotate-90"></i></span> [[topic:unpin-comment]]
 	</a>
 </li>
 {{{ end }}}

--- a/src/views/partials/topic/post-menu-list.tpl
+++ b/src/views/partials/topic/post-menu-list.tpl
@@ -16,6 +16,18 @@
 	</a>
 </li>
 {{{ end }}}
+{{{ if posts.canPin }}}
+<li {{{ if posts.pinned }}}hidden{{{ end }}}>
+	<a class="dropdown-item rounded-1 d-flex align-items-center gap-2" component="post/pin" role="menuitem" href="#" data-pid="{posts.pid}">
+		<span class="menu-icon"><i class="fa fa-fw text-secondary fa-thumb-tack"></i></span> [[topic:pin-post]]
+	</a>
+</li>
+<li {{{ if !posts.pinned }}}hidden{{{ end }}}>
+	<a class="dropdown-item rounded-1 d-flex align-items-center gap-2" component="post/unpin" role="menuitem" href="#" data-pid="{posts.pid}">
+		<span class="menu-icon"><i class="fa fa-fw text-secondary fa-thumb-tack fa-rotate-90"></i></span> [[topic:unpin-post]]
+	</a>
+</li>
+{{{ end }}}
 {{{ if posts.display_purge_tools }}}
 <li {{{ if !posts.deleted }}}hidden{{{ end }}}>
 	<a class="dropdown-item rounded-1 d-flex align-items-center gap-2" component="post/purge" role="menuitem" href="#" class="{{{ if !posts.deleted }}}hidden{{{ end }}}">

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic/post.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic/post.tpl
@@ -5,6 +5,15 @@
 	{{{ end }}}
 </div>
 {{{ end }}}
+<style>
+/* chat wrote the below */
+/* Small style for the inline pinned thumb-tack indicator */
+.pinned-icon {
+	font-size: 0.9em;
+	opacity: 0.85;
+	vertical-align: baseline;
+}
+</style>
 {{{ if (./parent && !hideParent) }}}
 <!-- IMPORT partials/topic/post-parent.tpl -->
 {{{ end }}}
@@ -61,6 +70,10 @@
 
 					<i component="post/edit-indicator" class="fa fa-edit text-muted{{{ if privileges.posts:history }}} pointer{{{ end }}} edit-icon {{{ if !posts.editor.username }}}hidden{{{ end }}}" title="[[global:edited-timestamp, {isoTimeToLocaleString(./editedISO, config.userLang)}]]"></i>
 					<span data-editor="{posts.editor.userslug}" component="post/editor" class="visually-hidden">[[global:last-edited-by, {posts.editor.username}]] <span class="timeago" title="{isoTimeToLocaleString(posts.editedISO, config.userLang)}"></span></span>
+
+					<!-- server-side small pinned indicator (mirrors client-side post/pinned-indicator) -->
+					<!-- I used copilot + GPT-5 and based this icon off of the edited post indicator code -->
+					<i component="post/pinned-indicator" class="fa fa-thumb-tack text-muted pinned-icon ms-1 {{{ if !posts.pinned }}}hidden{{{ end }}}" title="[[topic:pinned]]" aria-hidden="true"></i>
 				</div>
 
 				{{{ if posts.user.custom_profile_info.length }}}


### PR DESCRIPTION
**Context**
- Added pinned comment functionality, allowing the author of a post to pin comments / replies to their initial comment

**Description**
_Features of this include_
- a pinned / unpinned action in the comment drop-down list
- an icon denoting pinned / unpinned status
- comment location moved to be directly underneath the initial comment if pinned
- relative pinning order preserved; comment placed underneath other pinned comments in order of pinning
- unpinned location returned to normal by index (order of added comment)

**Changes in the code**
- viewable by the changes in the attached files, but a combination of route updates, controller + serializer changes, API file changes, UI additions, and JS actions for pinning and unpinning (and relative order)
**Tested**
- using localHost / "./nodebb start"

**Additional information**
- test account has credentials **U:** teditor, **P:** 123456#